### PR TITLE
FIX getcurpos invalid expression

### DIFF
--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -35,7 +35,7 @@ function! todo#PrioritizeDecrease()
 endfunction
 
 function! todo#PrioritizeAdd (priority)
-    let oldpos=getcurpos()
+    let oldpos=getpos('.')
     let line=getline('.')
     if line !~ '^([A-F])'
         :call todo#PrioritizeAddAction(a:priority)


### PR DESCRIPTION
getcurpos throws invalid expression, at least in my version. I change it by getpos('.') that is more "universal"
