### PR TITLE
Improve todo#PrependDate to follow format

### DIFF
--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -62,7 +62,11 @@ function! todo#RemovePriority()
 endfunction
 
 function! todo#PrependDate()
-    normal! 0"=strftime("%Y-%m-%d ")P
+    if (getline(".") =~ '\v^\(')
+	execute "normal! 0f)a\<space>\<esc>l\"=strftime(\"%Y-%m-%d\")\<esc>P"
+    else
+        normal! 0"=strftime("%Y-%m-%d ")P
+    endif
 endfunction
 
 function! todo#ToggleMarkAsDone(status)


### PR DESCRIPTION
Add logic to place the completion date after the priority, if it exists,
when completing a task.