### PR TITLE
Fix for <Leader>x and other minor issues

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,9 +28,9 @@
 
 ## Release notes
 
-+   V0.8.1 Incorporates yet antoher Fretep work : highlithing for tasks due today.
++   V0.8.1 Incorporates yet another Fretep work : highlighting for tasks due today.
 
-+   v0.8 Incorporates Fretep's work on overdue dates (PR#13 and PR#16) witch
++   v0.8 Incorporates Fretep's work on overdue dates (PR#13 and PR#16) which
 removes python dependency, allow to control the cursor position after a sort by
 todo (see (sort)[#sort] and/or issue #15) and fixes bug when sorting a file
 containing only lines with due:date (issue #14).
@@ -60,7 +60,7 @@ by David Beniamine.
 Todo.txt is a standard human readable todo notes file defined [here](http://todotxt.com):
 
 "The todo.txt format is a simple set of
-[rules](https://github.com/ginatrapani/todo.txt-cli/wiki/The-Todo.txt-Format)
+[rules](https://github.com/todotxt/todotxt/)
 that make todo.txt both human and machine-readable. The format supports
 priorities, creation and completion dates, projects and contexts. That's
 all you need to be productive. See an example Todo.txt file":
@@ -77,7 +77,7 @@ all you need to be productive. See an example Todo.txt file":
 ### Why this fork ?
 
 This plugin is a fork of [freitass
-todo.txt-vim](https://github.com/freitass/todo.txt-vim). It add severals cool
+todo.txt-vim](https://github.com/freitass/todo.txt-vim). It add several cool
 functionalities including:
 
 + [Hierarchical sort](##hierarchical-sort)
@@ -119,7 +119,7 @@ having copied the files.  Then you will be able to get the commands help with:
 
 ## TodoTxt Files
 
-This plugin provides a Flexible file naming for todo.txt, all the following
+This plugin provides flexible file naming for todo.txt, all the following
 names are recognized as todo:
 
     YYYY-MM-[Tt]odo.txt
@@ -200,7 +200,7 @@ For more information on the available flags see `help :sort`
 
 ## Mappings
 
-By default todo-txt.vim set all the mappings secribed in this section. To
+By default todo-txt.vim sets all the mappings described in this section. To
 prevent this behavior, add the following line to your vimrc
 
    let g:Todo_txt_do_not_map=1
@@ -214,13 +214,13 @@ prevent this behavior, add the following line to your vimrc
 + `<LocalLeader>s` : Sort the file by priority
 + `<LocalLeader>s+` : Sort the file on `+Projects`
 + `<LocalLeader>s@` : Sort the file on `@Contexts`
-+ `<LocalLeader>sd` : Sort the file on due dates
 + `<LocalLeader>sc` : Sort the file by context then by priority
 + `<LocalLeader>scp` : Sort the file by context, project then by priority
 + `<LocalLeader>sp` : Sort the file by project then by priority
 + `<LocalLeader>spc` : Sort the file by project, context then by priority
-+ `<leader>-sd` : Sort the file by due-date. Entries with a due date appears
-sorted by at the beginning of the file, the rest of the file is not modified.
++ `<LocalLeader>sd` : Sort the file on due dates. Entries with a due date appear
+sorted by at the beginning of the file, completed tasks are moved to the bottom and
+the rest of the file is not modified.
 
 When you sort by due dates, at the end of the sort, your cursor will be placed
 at the top of the file. This behavior can be set with the following global

--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -3,7 +3,6 @@
 " Author:      David Beniamine <david@beniamine.net>, Peter (fretep) <githib.5678@9ox.net>
 " Licence:     Vim licence
 " Website:     http://github.com/dbeniamine/todo.txt.vim
-" vim: ts=4 sw=4 :help tw=78 cc=80
 
 " These two variables are parameters for the successive calls the vim sort
 "   '' means no flags
@@ -30,7 +29,8 @@ function! todo#GetCurpos()
         return getpos('.')
 endfunction
 
-" Increment and Decrement The Priority
+" Increment and Decrement The Priority.
+" TODO: Make nrformats local to buffers of type todo
 :set nf=octal,hex,alpha
 
 function! todo#PrioritizeIncrease()
@@ -63,15 +63,14 @@ endfunction
 
 function! todo#PrependDate()
     if (getline(".") =~ '\v^\(')
-	    execute "normal! 0f)a\<space>\<esc>l\"=strftime(\"%Y-%m-%d\")\<esc>P"
+        execute "normal! 0f)a\<space>\<esc>l\"=strftime(\"%Y-%m-%d\")\<esc>P"
     else
-        normal! 0"=strftime("%Y-%m-%d ")
-        P
+        normal! I=strftime("%Y-%m-%d ")
     endif
 endfunction
 
 function! todo#ToggleMarkAsDone(status)
-    if (getline(".") =~ 'x\s*\d\{4\}')
+    if (getline(".") =~ '\C^\s*x\s*\d\{4\}')
         :call todo#UnMarkAsDone(a:status)
     else
         :call todo#MarkAsDone(a:status)
@@ -84,7 +83,7 @@ function! todo#UnMarkAsDone(status)
     else
         let pat=' '.a:status
     endif
-    exec ':s/\s*x\s*\d\{4}-\d\{1,2}-\d\{1,2}'.pat.'\s*//g'
+    exec ':s/\C^\s*x\s*\d\{4}-\d\{1,2}-\d\{1,2}'.pat.'\s*//g'
 endfunction
 
 function! todo#MarkAsDone(status)
@@ -138,6 +137,7 @@ function! todo#Sort()
     " vim :sort is usually stable
     " we sort first on contexts, then on projects and then on priority
     if expand('%')=~'[Dd]one.*.txt'
+        " FIXME: Put some unit tests around this, and fix case sensitivity if ignorecase is set.
         silent! %s/\(x\s*\d\{4}\)-\(\d\{2}\)-\(\d\{2}\)/\1\2\3/g
         sort n /^x\s*/
         silent! %s/\(x\s*\d\{4}\)\(\d\{2}\)/\1-\2-/g
@@ -443,4 +443,4 @@ fun! todo#Complete(findstart, base)
     endif
 endfun
 
-
+" vim: tabstop=4 shiftwidth=4 softtabstop=4 expandtab foldmethod=marker

--- a/autoload/todo/txt.vim
+++ b/autoload/todo/txt.vim
@@ -120,4 +120,4 @@ function! todo#txt#prioritize_add_action(priority)
 endfunction
 
 " Modeline {{{1
-" vim: ts=8 sw=4 sts=4 et foldenable foldmethod=marker foldcolumn=1
+" vim: tabstop=4 shiftwidth=4 softtabstop=4 expandtab foldmethod=marker

--- a/doc/todo.txt
+++ b/doc/todo.txt
@@ -31,9 +31,9 @@ Table of Contents                                          *TodoTxt-Contents* ~
 ===============================================================================
 1. Release notes                                       *TodoTxt-ReleaseNotes* ~
 
-V0.8.1 Incorporates yet antoher Fretep work : highlithing for tasks due today.
+V0.8.1 Incorporates yet another Fretep work : highlighting for tasks due today.
 
-v0.8 Incorporates Fretep's work on overdue dates (PR#13 and PR#16) witch removes
+v0.8 Incorporates Fretep's work on overdue dates (PR#13 and PR#16) which removes
 python dependency, allow to control the cursor position after a sort by todo
 (see |TodoTxt-Sort| and/or issue #15) and fixes bug when sorting a file
 containing only lines with due:date (issue #14).
@@ -66,7 +66,7 @@ by David Beniamine.
     http://todotxt.com
 
     "The todo.txt format is a simple set of
-    rules(https://github.com/ginatrapani/todo.txt-cli/wiki/The-Todo.txt-Format)
+    rules(https://github.com/todotxt/todotxt/)
     that make todo.txt both human and machine-readable. The format supports
     priorities, creation and completion dates, projects and contexts. That's
     all you need to be productive. See an example Todo.txt file":
@@ -83,7 +83,7 @@ by David Beniamine.
 2.2 Why this fork ?                                              *TodoTxt-Fork*
 
     This plugin is a fork of freitass todo.txt-vim
-    (https://github.com/freitass/todo.txt-vim). It add severals cool
+    (https://github.com/freitass/todo.txt-vim). It add several cool
     functionalities including:
 
     + Hierarchical sort: |TodoTxt-Sort| and |TodoTxt-HierarchicalSort|.
@@ -126,7 +126,7 @@ by David Beniamine.
 ===============================================================================
 3. TodoTxt Files                                              *TodoTxt-Files* ~
 
-This plugin provides a Flexible file naming for todo.txt, all the following
+This plugin provides a flexible file naming for todo.txt, all the following
 names are recognized as todo:
 >
     YYYY-MM-[Tt]odo.txt
@@ -210,7 +210,7 @@ For more information on the available flags see |:sort|
 ===============================================================================
 6. Mappings                                                *TodoTxt-Mappings* ~
 
-By default todo-txt.vim set all the mappings secribed in this section. To
+By default todo-txt.vim set all the mappings described in this section. To
 prevent this behavior, add the following line to your vimrc
 >
    let g:Todo_txt_do_not_map=1
@@ -224,8 +224,6 @@ prevent this behavior, add the following line to your vimrc
 
     `<LocalLeader>s@` : Sort the file on @Contexts
 
-    `<LocalLeader>sd` : Sort the file on due dates
-
     `<LocalLeader>sc` : Sort the file by context then by priority
 
     `<LocalLeader>scp` : Sort the file by context, project then by priority
@@ -234,8 +232,9 @@ prevent this behavior, add the following line to your vimrc
 
     `<LocalLeader>spc` : Sort the file by project, context then by priority
 
-    `<leader>-sd` : Sort the file by due-date. Entries with a due date appears
-    sorted by at the beginning of the file, the rest of the file is not modified.
+    `<LocalLeader>sd` : Sort the file on due dates. Entries with a due date appear
+    sorted by at the beginning of the file, completed tasks are moved to the bottom and
+    the rest of the file is not modified.
 
 When you sort by due dates, at the end of the sort, your cursor will be placed
 at the top of the file. This behavior can be set with the following global

--- a/ftdetect/todo.vim
+++ b/ftdetect/todo.vim
@@ -3,7 +3,6 @@
 " Author:      David Beniamine <david@beniamine.net>, Leandro Freitas <freitass@gmail.com>
 " License:     Vim license
 " Website:     http://github.com/dbeniamine/todo.txt-vim
-" vim: ts=4 sw=4 :help tw=78 cc=80
 
 autocmd BufNewFile,BufRead [Tt]odo.txt set filetype=todo
 autocmd BufNewFile,BufRead [Tt]odo-\d\\\{4\}-\d\\\{2\}-\d\\\{2\}.txt set filetype=todo
@@ -17,3 +16,5 @@ autocmd BufNewFile,BufRead [Dd]one-\d\\\{4\}-\d\\\{2\}.txt set filetype=todo
 autocmd BufNewFile,BufRead \d\\\{4\}-\d\\\{2\}-\d\\\{2\}-[Dd]one.txt set filetype=todo
 autocmd BufNewFile,BufRead \d\\\{4\}-\d\\\{2\}-[Dd]one.txt set filetype=todo
 autocmd BufNewFile,BufRead [Dd]one-[Tt]oday.txt set filetype=todo
+
+" vim: tabstop=4 shiftwidth=4 softtabstop=4 expandtab foldmethod=marker

--- a/ftplugin/todo.vim
+++ b/ftplugin/todo.vim
@@ -3,7 +3,6 @@
 " Author:      David Beniamine <David@Beniamine.net>, Leandro Freitas <freitass@gmail.com>
 " License:     Vim license
 " Website:     http://github.com/dbeniamine/todo.txt-vim
-" vim: ts=4 sw=4 :help tw=78 cc=80
 
 " Save context {{{1
 let s:save_cpo = &cpo
@@ -55,13 +54,13 @@ if !exists("g:Todo_txt_do_not_map")
 
 " Mark done {{{2
     noremap <script> <silent> <buffer> <Plug>DoToggleMarkAsDone :call todo#ToggleMarkAsDone('')<CR>
-                \:call repeat#set("\<Plug>DoToggleMarkAsDone")<CR>
+                \:silent! call repeat#set("\<Plug>DoToggleMarkAsDone")<CR>
     nmap <localleader>x <Plug>DoToggleMarkAsDone
     " noremap <script> <silent> <buffer> <localleader>x :call todo#ToggleMarkAsDone('')<CR>
 
 " Mark done {{{2
     noremap <script> <silent> <buffer> <Plug>DoCancel :call todo#ToggleMarkAsDone('Cancelled')<CR>
-                \:call repeat#set("\<Plug>DoCancel")<CR>
+                \:silent! call repeat#set("\<Plug>DoCancel")<CR>
     nmap <localleader>C <Plug>DoCancel
 
 " Mark all done {{{2
@@ -104,3 +103,5 @@ endfunction
 
 " Restore context {{{1
 let &cpo = s:save_cpo
+
+" vim: tabstop=4 shiftwidth=4 softtabstop=4 expandtab foldmethod=marker

--- a/syntax/todo.vim
+++ b/syntax/todo.vim
@@ -3,7 +3,6 @@
 " Author:      David Beniamine <David@Beniamine.net>,Leandro Freitas <freitass@gmail.com>
 " License:     Vim license
 " Website:     http://github.com/dbeniamine/todo.txt-vim
-" vim: ts=4 sw=4 :help tw=78 cc=80
 
 if exists("b:current_syntax")
     finish
@@ -42,9 +41,7 @@ syntax  match  TodoProject    '\(^\|\W\)+[^[:blank:]]\+'  contains=NONE
 syntax  match  TodoContext    '\(^\|\W\)@[^[:blank:]]\+'  contains=NONE
 
 let s:todayDate=strftime('%Y\-%m\-%d')
-"TODO: Figure out how to allow stop the following line being highlighted inside TodoDone
-"execute 'syntax match TodoDueToday    /\v\c<(due:)@4<=' . s:todayDate . '/ contains=NONE contained'
-execute 'syntax match TodoDueToday    /\v\c<due:' . s:todayDate . '/ contains=NONE'
+execute 'syntax match TodoDueToday    /\v\c<due:' . s:todayDate . '>/ contains=NONE'
 
 " Other priority colours might be defined by the user
 highlight  default  link  TodoKey        Special
@@ -158,16 +155,20 @@ function! todo#GetDateRegexForPastDates(...)
     " PART 6. Days of the month part 2.
     " i.e.  for 2017-09-07: "2017-09-0[0-6]"
     "       for 2017-12-29: "2017-12-2[0-8]"
-    let l:y = strpart(printf('%02d', l:day), 0, 1) " First digit of the day
-    let l:overdueRex = l:overdueRex . '(' . l:year . '\-' . printf('%02d', l:month) . '\-' . l:y
-    let l:y = strpart(printf('%02d', l:day), 1, 1) " Last digit of the day
-    if l:y > 0
-        let l:overdueRex = l:overdueRex . '[0-' . (l:y - 1) . ']'
-    else
-        let l:overdueRex = l:overdueRex . '0'
+    "       for 2017-09-20: skip
+    let l:d = strpart(printf('%02d', l:day), 1, 1) " Last digit of the day
+    if l:d > 0
+        let l:y = strpart(printf('%02d', l:day), 0, 1) " First digit of the day
+        let l:overdueRex = l:overdueRex . '(' . l:year . '\-' . printf('%02d', l:month) . '\-' . l:y
+        if l:d > 1
+            let l:overdueRex = l:overdueRex . '[0-' . (l:d - 1) . ']'
+        else
+            let l:overdueRex = l:overdueRex . '0'
+        endif
+        let l:overdueRex = l:overdueRex . ')'
     endif
-    let l:overdueRex = l:overdueRex . ')'
 
+    let l:overdueRex = substitute(l:overdueRex, '|$', '', 'e')
     let l:overdueRex = l:overdueRex . ')'
 
     return l:overdueRex
@@ -177,3 +178,5 @@ execute 'syntax match TodoOverDueDate /\v\c<due:' . todo#GetDateRegexForPastDate
 highlight default link TodoOverDueDate Error
 
 let b:current_syntax = "todo"
+
+" vim: tabstop=4 shiftwidth=4 softtabstop=4 expandtab foldmethod=marker

--- a/tests/clean-vim.sh
+++ b/tests/clean-vim.sh
@@ -1,0 +1,16 @@
+#/bin/bash
+
+# Start a clean vim for testing development.
+
+REPO_TOP=$(git rev-parse --show-toplevel)
+cd "${REPO_TOP}"
+
+vim -Nu <(cat <<EOF
+filetype off
+set rtp+=~/.vim/bundle/vader.vim
+set rtp+=./
+filetype plugin indent on
+syntax enable
+EOF
+) tests/todo.txt
+

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,0 +1,46 @@
+#/bin/bash
+
+REPO_TOP=$(git rev-parse --show-toplevel)
+cd "${REPO_TOP}"
+
+echo "Basic environment"
+echo "-----------------"
+vim -Nu <(cat <<EOF
+filetype off
+set rtp+=~/.vim/bundle/vader.vim
+set rtp+=./
+filetype plugin indent on
+syntax enable
+EOF
+) +Vader! tests/*.vader && echo Success || exit 1
+
+# Run through variations of user preferences that might mess with us.
+echo
+echo "Ignore case enabled"
+echo "-------------------"
+vim -Nu <(cat <<EOF
+filetype off
+set rtp+=~/.vim/bundle/vader.vim
+set rtp+=./
+filetype plugin indent on
+syntax enable
+set ignorecase
+EOF
+) +Vader! tests/*.vader && echo Success || exit 1
+
+echo
+echo "no hyphen in iskeyword"
+echo "----------------------"
+vim -Nu <(cat <<EOF
+filetype off
+set rtp+=~/.vim/bundle/vader.vim
+set rtp+=./
+filetype plugin indent on
+syntax enable
+set iskeyword+=-
+EOF
+) +Vader! tests/*.vader && echo Success || exit 1
+
+echo
+echo "All tests are passing."
+echo

--- a/tests/todo.txt
+++ b/tests/todo.txt
@@ -1,0 +1,118 @@
+x Test todo.txt file with a number of test cases from the vader unit tests for quick manual checks.
+x   .    1    .    2    .    3    .    4    .    5    .    6    .    7    .    8  L01
+x 345678901234567890123456789012345678901234567890123456789012345678901234567890  L02
+x (A) Done  due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L03
+Active      due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L04
+x 345678901234567890123456789012345678901234567890123456789012345678901234567890  L05
+x   .    1    .    2    .    3    .    4    .    5    .    6    .    7    .    8  L06
+x   .    1    .    2    .    3    .    4    .    5    .    6    .    7    .    8  L01
+x 345678901234567890123456789012345678901234567890123456789012345678901234567890  L02
+(A) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L03
+(B) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L04
+(C) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L05
+(D) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L06
+(E) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L07
+(F) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L08
+(G) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L09
+(H) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L10
+(I) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L11
+(J) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L12
+(K) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L13
+(L) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L14
+(M) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L15
+(N) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L16
+(O) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L17
+(P) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L18
+(Q) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L19
+(R) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L20
+(S) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L21
+(T) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L22
+(U) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L23
+(V) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L24
+(W) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L25
+(X) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L26
+(Y) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L27
+(Z) Priorit due:2000-01-01 due:2050-01-01 2017-09-10 +Project @Context key:value  L28
+x 345678901234567890123456789012345678901234567890123456789012345678901234567890  L29
+x   .    1    .    2    .    3    .    4    .    5    .    6    .    7    .    8  L30
+x   .    1    .    2    .    3    .    4    .    5    .    6    .    7    .    8  L01
+x 345678901234567890123456789012345678901234567890123456789012345678901234567890  L02
+X Done tasks must start with a lowercase x then space                             L03
+xDone tasks must start with a lowercase x then space                              L04
+XDone tasks must start with a lowercase x then space                              L05
+(a) Priority must start with an uppercase letter in rounds followed by space      L06
+(A)Priority must start with an uppercase letter in rounds followed by space       L07
+A  Priority must start with an uppercase letter in rounds followed by space       L08
+a  Priority must start with an uppercase letter in rounds followed by space       L09
+Priority (A) must start with an uppercase letter in rounds followed by space      L10
+due:2050-01-01 keys are valid on the start of the line                            L11
+due:2010-01-01 overdue dates are valid on the start of the line                   L12
+2010-01-01 dates are valid on the start of the line                               L13
+x   .    1    .    2    .    3    .    4    .    5    .    6    .    7    .    8  L14
+x 345678901234567890123456789012345678901234567890123456789012345678901234567890  L15
+Invalid dates 17-10-05 20100101 01-01-2010 2010/01/01 10/01/01 2010-01-01-2010    L16
+@Contexts are valid on the start of the line                                      L17
++Projects are valid on the start of the line                                      L18
+The key: syntax must be followed by a value, same for due:                        L19
+due: syntax must be a whole word notdue:2010-01-01 pro@jects and con+texts also   L20
+x 345678901234567890123456789012345678901234567890123456789012345678901234567890  L21
+x   .    1    .    2    .    3    .    4    .    5    .    6    .    7    .    8  L22
+x 2017-09-18 Complete task
+x 2017-09-18 2017-09-01 Completed task with a created date
+x 2017-09-18 (A) Completed priority task
+x 2017-09-18 2017-09-01 (A) Completed priority task with a created date
+X 2017-09-18 Not to be confused for a complete task
+Active task
+2017-09-01 Active task with a created date
+(A) Active priority task
+(A) 2017-09-01 Active priority task with a created date
+X 2017-09-18 Not to be confused for a complete task
+XNot to be confused for a complete task
+ x 2017-09-18 Rules are not clear on leading whitespace, see comments in test
+Tricky incomplete task x 2017-09-18
+active  dUE:2051-01-01 cAsE                                     EXP:24 GIV:01
+overdue due:2001-01-01                                          EXP:02 GIV:02
+notdue  overdue:2011-11-11 invalid key                          EXP:33 GIV:03
+overdue duE:2009-01-01 cAsE                                     EXP:18 GIV:04
+xoverdue due:2001-02-01 This is not done (must be lower x)      EXP:03 GIV:05
+overdue due:2012-01-01 \|| no tasks the between bars ||/        EXP:21 GIV:06
+x done  due:2011-11-11 topmost done task                        EXP:44 GIV:07
+notdue  due: 2011-11-11 space invalidates due:                  EXP:34 GIV:08
+overdue due:2005-01-01 +Project @Context                        EXP:10 GIV:09
+overdue due:2002-01-01 @Context                                 EXP:04 GIV:10
+overdue due:2004-02-01                                          EXP:09 GIV:11
+notdue  due: due:2011-MM-DD                                     EXP:35 GIV:12
+overdue due:2000-01-01 cursor here for top, most overdue        EXP:01 GIV:13
+notdue  due:2011-11-1                                           EXP:36 GIV:14
+active  due:2059-01-01 bottommost active task                   EXP:32 GIV:15
+overdue due:2006-01-01                                          EXP:12 GIV:16
+overdue due:2007-02-01 +Project                                 EXP:15 GIV:17
+active  due:2056-01-01                                          EXP:29 GIV:18
+notdue  due:2011-1-11                                           EXP:37 GIV:19
+x done  due:2011-11-11                                          EXP:45 GIV:20
+overdue dUe:2008-02-01 cAsE                                     EXP:17 GIV:21
+X overdue due:2002-02-01 This is not done (must be lower x)     EXP:05 GIV:22
++Project overdue due:2003-02-01 project at start of line        EXP:07 GIV:23
+notdue  due:2011                                                EXP:38 GIV:24
+active  DUe:2052-01-01 cAsE                                     EXP:25 GIV:25
+overdue due:2007-01-01                                          EXP:14 GIV:26
+overdue Due:2008-01-01 cAsE                                     EXP:16 GIV:27
+notdue  @Project                                                EXP:39 GIV:28
+active  due:2055-01-01                                          EXP:28 GIV:29
+active  due:2057-01-01                                          EXP:30 GIV:30
+overdue DuE:2009-02-01 cAsE                                     EXP:19 GIV:31
+notdue  @Context                                                EXP:40 GIV:32
+x done  due:2011-11-11 bottommost done task cursor here bottom  EXP:46 GIV:33
+active  DUE:2053-01-01 cAsE                                     EXP:26 GIV:34
+active  key:value due:2054-01-01 leading key:value              EXP:27 GIV:35
+active  due:2058-01-01                                          EXP:31 GIV:36
+notdue  key:value                                               EXP:41 GIV:37
+overdue due:2017-01-01 Last overdue task when sorted            EXP:22 GIV:38
+overdue due:2010-12-31 /|| no tasks the between bars ||\        EXP:20 GIV:39
+active  due:2050-01-01 cursor here with "notoverdue" setting    EXP:23 GIV:40
+notdue  due:invalid    invalid due date                         EXP:42 GIV:41
+overdue 2011-11-11 due:2005-02-01 leading date                  EXP:11 GIV:42
+due:2004-01-01 overdue due: at start of line                    EXP:08 GIV:43
+notdue  notdue:2011-11-11 invalid key                           EXP:43 GIV:44
+overdue due:2006-02-01 due:2011-11-11 two dates, choose first   EXP:13 GIV:45
+@Context overdue due:2003-01-01 context at start of line        EXP:06 GIV:46

--- a/tests/todo.vader
+++ b/tests/todo.vader
@@ -3,7 +3,6 @@
 " Author:      Peter (fretep) <githib.5678@9ox.net>
 " Licence:     Vim licence
 " Website:     http://github.com/dbeniamine/todo.txt.vim
-" vim: ts=2 sw=2 sts=2 expandtab :help tw=78 cc=80 foldmethod=marker
 
 " [Vader](https://github.com/junegunn/vader.vim) is a simple unit testing
 " plugin for VIM.
@@ -416,7 +415,73 @@ Execute (16-12-31 should NOT match with reference 17-12-31):
 Execute (2016-12-31 should NOT match with reference 17-12-31):
   Assert '2016-12-31' !~ b:rex
 
+" Make sure current date doesn't match
+Before:
+  let b:rex = todo#GetDateRegexForPastDates(strftime("%Y"), strftime("%m"), strftime("%d"))
+Execute (Log generated RegExp):
+  Log b:rex
+Execute (Current date should not match):
+  Assert strftime("%Y-%m-%d") !~ b:rex
+
+" Incorrectly matching current date, some breakpoints that previously were found to be an issue
+Before:
+  let b:rex = todo#GetDateRegexForPastDates(2017,09,20)
+Execute (Log generated RegExp):
+  Log b:rex
+Execute (2017-09-19 should match with reference 2017-09-20):
+  Assert '2017-09-19' =~ b:rex
+Execute (2017-09-20 should NOT match with reference 2017-09-20):
+  Assert '2017-09-20' !~ b:rex
+Before:
+  let b:rex = todo#GetDateRegexForPastDates(2017,09,30)
+Execute (Log generated RegExp):
+  Log b:rex
+Execute (2017-09-29 should match with reference 2017-09-30):
+  Assert '2017-09-29' =~ b:rex
+Execute (2017-09-30 should NOT match with reference 2017-09-30):
+  Assert '2017-09-30' !~ b:rex
+
 " file: autoload/todo.vim {{{1
+
+" function! todo#ToggleMarkAsDone(status) {{{2
+
+" NOTES:
+"   - Rules on leading whitespace is not clear, and really could be taken
+"     either way. Current behaviour is to treat leading whitespace as valid.
+"     TODO: Ensure behavior of leading whitespace is consistent for everything
+"     including priorities (which are currently not).
+"   - FIXME: Incorrect handling of priorities is expected below, see #21.
+Given todo (Tasks):
+  x 2017-09-18 Complete task
+  x 2017-09-18 2017-09-01 Completed task with a created date
+  x 2017-09-18 (A) Completed priority task
+  x 2017-09-18 2017-09-01 (A) Completed priority task with a created date
+  X 2017-09-18 Not to be confused for a complete task
+  Active task
+  2017-09-01 Active task with a created date
+  (A) Active priority task
+  (A) 2017-09-01 Active priority task with a created date
+  X 2017-09-18 Not to be confused for a complete task
+  XNot to be confused for a complete task
+   x 2017-09-18 Rules are not clear on leading whitespace, see comments in test
+  Tricky incomplete task x 2017-09-18
+Execute (Toggle completed):
+  global/./call todo#ToggleMarkAsDone('')
+  execute "%substitute/" . strftime("%Y-%m-%d") . "/**TODAY**/"
+Expect todo (Toggled tasks with today as **TODAY**):
+  Complete task
+  2017-09-01 Completed task with a created date
+  (A) Completed priority task
+  2017-09-01 (A) Completed priority task with a created date
+  x **TODAY** X 2017-09-18 Not to be confused for a complete task
+  x **TODAY** Active task
+  x **TODAY** 2017-09-01 Active task with a created date
+  x (A) **TODAY** Active priority task
+  x (A) **TODAY** 2017-09-01 Active priority task with a created date
+  x **TODAY** X 2017-09-18 Not to be confused for a complete task
+  x **TODAY** XNot to be confused for a complete task
+  Rules are not clear on leading whitespace, see comments in test
+  x **TODAY** Tricky incomplete task x 2017-09-18
 
 " function: todo#SortDue() {{{2
 
@@ -678,3 +743,4 @@ Then (Is cursor on first non-overdue task?):
 After:
     unlet g:TodoTxtSortDueDateCursorPos
 
+" vim: tabstop=2 shiftwidth=2 softtabstop=2 expandtab foldmethod=marker


### PR DESCRIPTION
Fixed a bug in `<Leader>x` (todo#PrependDate) introduced last commit.
Fixed case sensitivity bug in todo#ToggleMarkAsDone() and todo#UnMarkAsDone()
Fixed errors being reported for repeat#set if vim-repeat plugin is not installed.
Fixed modeline in .vim files to work (only works on first/last 5 lines of file), and made the modelines consistent across all files.
New unit tests for todo#ToggleMarkAsDone()
Minor fixes for README.md and man page
Fix anchoring of RegExp in todo#ToggleMarkAsDone
Fixed a bug in overdue highlighting that resulted in the current date being matched on round dates like the 20th and 30th.
Added more unit tests for overdue date highlighting.
Corrected RegExp anchoring on today date highlighting.
Added a few bash scripts to make running unit tests easier and more reliable, including testing with ignorecase user preference set.