### PR TITLE
Option to prefix creation date when opening a new line

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -178,6 +178,11 @@ following lines to your vimrc:
 
     au filetype todo setlocal completeopt-=preview
 
+If you would like the preview window to open even if there is only one match for
+a completion, then add the following lines to your vimrc:
+
+    au filetype todo setlocal completeopt+=menuone
+
 
 ## Hierarchical sort
 
@@ -255,6 +260,12 @@ Possible values are :
 + `date<tab>`  : (Insert mode) Insert the current date
 + `due:`  : (Insert mode) Insert `due:` followed by the current date
 + `DUE:`  : (Insert mode) Insert `DUE:` followed by the current date
+
+If you would like the creation date (today) prefixed on new lines, add the
+following to your vimrc:
+
+    let g:Todo_txt_prefix_creation_date=1
+
 
 ### Done
 

--- a/doc/todo.txt
+++ b/doc/todo.txt
@@ -188,6 +188,12 @@ following lines to your vimrc:
     au filetype todo setlocal completeopt-=preview
 <
 
+If you would like the preview window to open even if there is only one match for
+a completion, then add the following lines to your vimrc:
+>
+    au filetype todo setlocal completeopt+=menuone
+<
+
 ===============================================================================
 5. Hierarchical sort                               *TodoTxt-HierarchicalSort* ~
 
@@ -277,6 +283,12 @@ Possible values are :
     `due:`  : (Insert mode) Insert `due:` followed by the current date
 
     `DUE:`  : (Insert mode) Insert `DUE:` followed by the current date
+
+If you would like the creation date (today) prefixed on new lines, add the
+following to your vimrc:
+>
+    let g:Todo_txt_prefix_creation_date=1
+<
 
 6.4 Done                                                         *TodoTxt-Done*
 

--- a/ftplugin/todo.vim
+++ b/ftplugin/todo.vim
@@ -4,15 +4,15 @@
 " License:     Vim license
 " Website:     http://github.com/dbeniamine/todo.txt-vim
 
-" Save context {{{1
-let s:save_cpo = &cpo
-set cpo&vim
-
 if exists("g:Todo_txt_loaded")
     finish
 else
     let g:Todo_txt_loaded=0.8.1
 endif
+
+" Save context {{{1
+let s:save_cpo = &cpo
+set cpo&vim
 
 " General options {{{1
 " Some options lose their values when window changes. They will be set every
@@ -73,6 +73,13 @@ if !exists("g:Todo_txt_do_not_map")
     nnoremap <script> <silent> <buffer> <localleader>sd :call todo#SortDue()<CR>
 " try fix format {{{2
     nnoremap <script> <silent> <buffer> <localleader>ff :call todo#FixFormat()<CR>
+
+" Prefix creation date when opening a new line {{{2
+    if exists("g:Todo_txt_prefix_creation_date")
+        nnoremap <script> <silent> <buffer> o o<C-R>=strftime("%Y-%m-%d")<CR> 
+        nnoremap <script> <silent> <buffer> O O<C-R>=strftime("%Y-%m-%d")<CR> 
+        inoremap <script> <silent> <buffer> <CR> <CR><C-R>=strftime("%Y-%m-%d")<CR> 
+    endif
 endif
 
 " Folding {{{1

--- a/tests/todo.vader
+++ b/tests/todo.vader
@@ -504,6 +504,10 @@ Execute (Check todo#ToggleMarkAsDone for exceptions):
 
 Before:
     let g:TodoTxtSortDueDateCursorPos = "top"
+After:
+  if exists("g:TodoTxtSortDueDateCursorPos")
+    unlet g:TodoTxtSortDueDateCursorPos
+  endif
 " In given/expected lists:
 "     GIV:xx is the order the task is given
 "     EXP:xx is the order the task is expected to be sorted into
@@ -757,10 +761,10 @@ Do (Sort and check cursor position: notoverdue):
 Then (Is cursor on first non-overdue task?):
   AssertEqual 1, line('.')
 
-After:
-    unlet g:TodoTxtSortDueDateCursorPos
 
 " function todo#Complete(findstart, base) {{{2
+Before:
+After:
 Given todo (Tasks):
   2017-09-23 Test task +SecretProject @Work due:2017-09-26
   Tricky lowercase @wrongCaseSelected +selectedWrongCase
@@ -789,8 +793,46 @@ Expect (Project SecretProject):
 
 " file: ftplugin/todo.vim {{{1
 
+" Mappings {{{2
+
+Before:
+  let g:Todo_txt_prefix_creation_date=0
+After:
+  unlet g:Todo_txt_prefix_creation_date
+Given todo (Empty buffer):
+Do (Open a new line - o):
+  oNew task
+Expect todo (New task with no creation date):
+  
+  New task
+Before:
+  let g:Todo_txt_prefix_creation_date=1
+  unlet g:Todo_txt_loaded
+  source ftplugin/todo.vim
+After:
+  unlet g:Todo_txt_prefix_creation_date
+  nunmap <buffer> o
+  nunmap <buffer> O
+  iunmap <buffer> <CR>
+Given todo (Empty buffer):
+Execute (Open some new lines):
+  :normal oNew task o
+  :normal ONew task O
+  :normal ANew task CR
+  execute "%substitute/" . strftime("%Y-%m-%d") . "/**TODAY**/"
+Expect todo (New task with no creation date):
+  
+  **TODAY** New task O
+  **TODAY** New task CR
+  **TODAY** New task o
+Before:
+After:
+
+
 " function: TodoFoldLevel(lnum) {{{2
 
+Before:
+After:
 Given todo (Tasks):
   active  due:2050-01-01 task                                     L:01
   x 2017-09-01 complete task 1                                    L:02


### PR DESCRIPTION
For those who like the creation date on all tasks, this option creates mappings to prepend the creation date when opening a new line