### PR TITLE
Add setting for dropping priority metadata

### DIFF
--- a/autoload/todo.vim
+++ b/autoload/todo.vim
@@ -102,7 +102,11 @@ endfunction
 
 function! todo#MarkAsDone(status)
     call todo#CreateNewRecurrence(1)
-    exec ':s/\C^(\([A-Z]\))\(.*\)/\2 pri:\1/e'
+    if get(g:, 'TodoTxtStripDoneItemPriority', 0)
+        exec ':s/\C^(\([A-Z]\))\(.*\)/\2/e'
+    else
+        exec ':s/\C^(\([A-Z]\))\(.*\)/\2 pri:\1/e'
+    endif
     if a:status!=''
         exec 'normal! I'.a:status.' '
     endif


### PR DESCRIPTION
The default behavior of todo.txt is to add priority metadata to done
items with priority tags so that the priority can be restored when the
item is marked as undone. If you want to have cleaner done items and
just remove the priority information when the item is set as done, set

    let g:TodoTxtStripDoneItemPriority=1